### PR TITLE
Use IP instead of mobile.nuget.couchbase.com

### DIFF
--- a/PromoteBuild.ps1
+++ b/PromoteBuild.ps1
@@ -61,8 +61,8 @@ try {
     } else {
         $package_names = "Couchbase.Lite","Couchbase.Lite.Enterprise","Couchbase.Lite.Support.Android","Couchbase.Lite.Support.iOS","Couchbase.Lite.Support.NetDesktop","Couchbase.Lite.Support.UWP","Couchbase.Lite.Enterprise.Support.Android","Couchbase.Lite.Enterprise.Support.iOS","Couchbase.Lite.Enterprise.Support.NetDesktop","Couchbase.Lite.Enterprise.Support.UWP"
         foreach($package in $package_names) {
-            Write-Host "Downloading http://mobile.nuget.couchbase.com/nuget/Internal/package/$package/$InVersion..."
-            Invoke-WebRequest http://mobile.nuget.couchbase.com/nuget/Internal/package/$package/$InVersion -OutFile "${package}.${InVersion}.nupkg"
+            Write-Host "Downloading http://172.23.121.218/nuget/Internal/package/$package/$InVersion..."
+            Invoke-WebRequest http://172.23.121.218/nuget/Internal/package/$package/$InVersion -OutFile "${package}.${InVersion}.nupkg"
         }
     }
 

--- a/PushBuild.ps1
+++ b/PushBuild.ps1
@@ -41,7 +41,7 @@ if(-Not $Prerelease) {
     Read-S3Object -BucketName packages.couchbase.com -KeyPrefix releases/couchbase-lite-net/$Version -Folder . -AccessKey $AccessKey -SecretKey $SecretKey
     $NugetUrl = "https://api.nuget.org/v3/index.json"
 } else {
-    $NugetUrl = "http://mobile.nuget.couchbase.com/nuget/Developer"
+    $NugetUrl = "http://172.23.121.218/nuget/Developer"
 }
 
 if(-Not $(Test-Path .\nuget.exe) -and -not $DryRun) {
@@ -50,7 +50,7 @@ if(-Not $(Test-Path .\nuget.exe) -and -not $DryRun) {
 
 foreach($file in (Get-ChildItem $pwd -Filter *.nupkg)) {
     if($Prerelease) {
-        $NugetUrl = "http://mobile.nuget.couchbase.com/nuget/Developer"
+        $NugetUrl = "http://172.23.121.218/nuget/Developer"
     } else {
         $NugetUrl = "https://api.nuget.org/v3/index.json"
     }


### PR DESCRIPTION
This is required for CBL 2.6.0 release and possible sub-sequence releases, until the proxy is fix.